### PR TITLE
Load history with localized timezone

### DIFF
--- a/src/Shotr.Ui/Forms/MainForm.cs
+++ b/src/Shotr.Ui/Forms/MainForm.cs
@@ -483,7 +483,7 @@ namespace Shotr.Ui.Forms
                     {
                         Text = $"https://shotr.dev/{item.Name}",
                     };
-                    listViewItem.SubItems.Add(item.Time.ToString());
+                    listViewItem.SubItems.Add(item.Time.ToLocalTime().ToString());
 
                     themedListView1.Items.Add(listViewItem);
                 }


### PR DESCRIPTION
Closes #82 
New screenshots are appended with the correct time already. This issue was specific to history that's loaded in from the server.