### PR TITLE
Revert "Fix startup with windows"

### DIFF
--- a/src/Shotr.Ui/Program.cs
+++ b/src/Shotr.Ui/Program.cs
@@ -160,11 +160,6 @@ namespace Shotr.Ui
             var form = ServiceProvider.GetService<MainForm>();
             var settings = ServiceProvider.GetService<BaseSettings>();
             var hotkeys = ServiceProvider.GetService<HotKeyService>();
-
-            if (settings.StartWithWindows)
-            {
-                Utils.AddToStartup(settings.StartWithWindows);
-            }
             
             hotkeys.LoadHotKeys();
             


### PR DESCRIPTION
Windows Defender picks this up as a false positive. Let's revert this change. Maybe we can push it out quickly as a bug fix instead of waiting until next release.

Reverts - https://github.com/shotr-io/shotr-3/commit/213985a078b4bdcf600718456f213c4fe6b8d286